### PR TITLE
[Bugfix] Rename the Test_Superclass to Test

### DIFF
--- a/test_superclass.rb
+++ b/test_superclass.rb
@@ -1,4 +1,4 @@
-class Test_Superclass
+class Test
   def run
     # calls all methods ending on _test
     symbols = self.methods


### PR DESCRIPTION
Hey :+1: Looks good! I had a problem when running the tests though:

``` shell
ruby test_superclass.rb
```

Gave me the error:

```
/Users/moonglum/Code/nano_padawans_test/monster_test.rb:3:in `<top (required)>': uninitialized constant Test (NameError)
    from test_superclass.rb:40:in `require_relative'
    from test_superclass.rb:40:in `<main>'
```

I fixed it by renaming the `Test_Superclass` to `Test`. Now I get the following output:

```
ruby test_superclass.rb
[Monster_Test]
New subclass: Monster_Test
[Monster_Test]
"Elza ate meat"
victory
```

:smile:
